### PR TITLE
feat: add email validation macro and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,51 @@
 # Email Validation Macro
 
+[![CodeFactor](https://www.codefactor.io/repository/github/josetorronteras/emailvalidationmacro/badge)](https://www.codefactor.io/repository/github/josetorronteras/emailvalidationmacro)
+
 Email Validation Macro is a Swift macro framework for validating email addresses.
+
+
+* [Basic Usage](#basic-usage)
+* [Installation](#installation)
+
+## Basic Usage
+
+```swift
+// Create and validate an email address
+let validEmail = #email("foo@email.com")
+
+let invalidEmail = #email("foo@.com") // ❌
+```
+
+## Installation
+
+### Swift Package Manager
+
+Add the following line to the dependencies in `Package.swift`:
+
+```swift
+.package(
+    url: "https://github.com/josetorronteras/EmailValidationMacro",
+    from: "1.0.0"
+),
+```
+
+Then add `EmailValidationMacro` to your target's dependencies:
+
+```swift
+.product(
+    name: "EmailValidation",
+    package: "EmailValidationMacro"
+),
+```
+
+### Xcode
+
+Go to `File > Add Package Dependencies...` and paste the repo's URL:
+
+```
+https://github.com/josetorronteras/EmailValidationMacro
+```
 
 ## License
 

--- a/Sources/EmailValidation/EmailValidation.swift
+++ b/Sources/EmailValidation/EmailValidation.swift
@@ -14,4 +14,5 @@
 /// print(validatedEmail) // Output: "foo@email.com"
 /// ```
 @freestanding(expression)
-public macro email(_ email: String) -> String = #externalMacro(module: "EmailValidationMacros", type: "EmailValidationMacro")
+public macro email(_ email: String) -> String =
+    #externalMacro(module: "EmailValidationMacros", type: "EmailValidationMacro")

--- a/Sources/EmailValidation/EmailValidation.swift
+++ b/Sources/EmailValidation/EmailValidation.swift
@@ -1,12 +1,17 @@
 // The Swift Programming Language
 // https://docs.swift.org/swift-book
 
-/// A macro that produces both a value and a string containing the
-/// source code that generated the value. For example,
+/// Macro that Validates the provided email address.
 ///
-///     #stringify(x + y)
+/// - Parameters:
+///   - email: The email address to validate.
+/// - Returns: The validated email address if valid.
 ///
-/// produces a tuple `(x + y, "x + y")`.
+/// Example:
+/// ```swift
+/// // Example usage of the email validation macro
+/// let validatedEmail = #email("foo@email.com")
+/// print(validatedEmail) // Output: "foo@email.com"
+/// ```
 @freestanding(expression)
-public macro stringify<T>(_ value: T) -> (T, String) =
-    #externalMacro(module: "EmailValidationMacros", type: "StringifyMacro")
+public macro email(_ email: String) -> String = #externalMacro(module: "EmailValidationMacros", type: "EmailValidationMacro")

--- a/Sources/EmailValidationClient/main.swift
+++ b/Sources/EmailValidationClient/main.swift
@@ -1,8 +1,5 @@
 import EmailValidation
 
-let a = 17
-let b = 25
+let email = #email("foo@email.com")
 
-let (result, code) = #stringify(a + b)
-
-print("The value \(result) was produced by the code \"\(code)\"")
+print(email)

--- a/Sources/EmailValidationMacros/EmailValidationMacro.swift
+++ b/Sources/EmailValidationMacros/EmailValidationMacro.swift
@@ -2,32 +2,52 @@ import SwiftCompilerPlugin
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
-
-/// Implementation of the `stringify` macro, which takes an expression
-/// of any type and produces a tuple containing the value of that expression
-/// and the source code that produced the value. For example
-///
-///     #stringify(x + y)
-///
-///  will expand to
-///
-///     (x + y, "x + y")
-public struct StringifyMacro: ExpressionMacro {
-    public static func expansion(
-        of node: some FreestandingMacroExpansionSyntax,
-        in context: some MacroExpansionContext
-    ) -> ExprSyntax {
-        guard let argument = node.argumentList.first?.expression else {
-            fatalError("compiler bug: the macro does not have any arguments")
-        }
-
-        return "(\(argument), \(literal: argument.description))"
-    }
-}
+import Foundation
 
 @main
 struct EmailValidationPlugin: CompilerPlugin {
     let providingMacros: [Macro.Type] = [
-        StringifyMacro.self
+        EmailValidationMacro.self,
     ]
+}
+
+/// Validates the provided email address and returns it if valid.
+///
+/// Example:
+/// ```swift
+/// // Example usage of the email validation macro
+/// let validatedEmail = #email("foo@email.com")
+/// print(validatedEmail) // Output: "foo@email.com"
+/// ```
+public struct EmailValidationMacro: ExpressionMacro {
+    public static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> ExprSyntax {
+        guard let argument = node.argumentList.first?.expression,
+              let segments = argument.as(StringLiteralExprSyntax.self)?.segments,
+              segments.count == 1,
+              case .stringSegment(let literalSegment)? = segments.first else {
+            throw EmailValidationMacroError.requiresStaticStringLiteral
+        }
+        
+        let email = literalSegment.content.text
+        guard isValidEmail(email) else {
+            throw EmailValidationMacroError.malformedEmail
+        }
+        
+        return "\(argument)"
+    }
+}
+
+/// Validates whether a given string is a valid email address.
+///
+/// - Parameter email: The string to validate as an email address.
+/// - Returns: `true` if the string is a valid email address; otherwise, `false`.
+///
+/// - Note: This function uses a regular expression pattern to validate email addresses.
+func isValidEmail(_ email: String) -> Bool {
+    let emailRegex = #"^[\w\.-]+@[a-zA-Z\d-]+(?:\.[a-zA-Z\d-]+)*\.[a-zA-Z]{2,}$"#
+    let emailPredicate = NSPredicate(format: "SELF MATCHES %@", emailRegex)
+    return emailPredicate.evaluate(with: email)
 }

--- a/Sources/EmailValidationMacros/EmailValidationMacro.swift
+++ b/Sources/EmailValidationMacros/EmailValidationMacro.swift
@@ -1,13 +1,13 @@
+import Foundation
 import SwiftCompilerPlugin
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
-import Foundation
 
 @main
 struct EmailValidationPlugin: CompilerPlugin {
     let providingMacros: [Macro.Type] = [
-        EmailValidationMacro.self,
+        EmailValidationMacro.self
     ]
 }
 
@@ -25,17 +25,18 @@ public struct EmailValidationMacro: ExpressionMacro {
         in context: some MacroExpansionContext
     ) throws -> ExprSyntax {
         guard let argument = node.argumentList.first?.expression,
-              let segments = argument.as(StringLiteralExprSyntax.self)?.segments,
-              segments.count == 1,
-              case .stringSegment(let literalSegment)? = segments.first else {
+            let segments = argument.as(StringLiteralExprSyntax.self)?.segments,
+            segments.count == 1,
+            case .stringSegment(let literalSegment)? = segments.first
+        else {
             throw EmailValidationMacroError.requiresStaticStringLiteral
         }
-        
+
         let email = literalSegment.content.text
         guard isValidEmail(email) else {
             throw EmailValidationMacroError.malformedEmail
         }
-        
+
         return "\(argument)"
     }
 }

--- a/Sources/EmailValidationMacros/EmailValidationMacroError.swift
+++ b/Sources/EmailValidationMacros/EmailValidationMacroError.swift
@@ -1,7 +1,7 @@
 enum EmailValidationMacroError: Error, CustomStringConvertible {
     case requiresStaticStringLiteral
     case malformedEmail
-    
+
     var description: String {
         switch self {
         case .requiresStaticStringLiteral:

--- a/Sources/EmailValidationMacros/EmailValidationMacroError.swift
+++ b/Sources/EmailValidationMacros/EmailValidationMacroError.swift
@@ -1,0 +1,13 @@
+enum EmailValidationMacroError: Error, CustomStringConvertible {
+    case requiresStaticStringLiteral
+    case malformedEmail
+    
+    var description: String {
+        switch self {
+        case .requiresStaticStringLiteral:
+            "Requires a static string literal"
+        case .malformedEmail:
+            "The input email is malformed"
+        }
+    }
+}

--- a/Tests/EmailValidationTests/EmailValidationTests.swift
+++ b/Tests/EmailValidationTests/EmailValidationTests.swift
@@ -4,69 +4,69 @@ import XCTest
 
 // Macro implementations build for the host, so the corresponding module is not available when cross-compiling. Cross-compiled tests may still make use of the macro itself in end-to-end tests.
 #if canImport(EmailValidationMacros)
-import EmailValidationMacros
+    import EmailValidationMacros
 
-let testMacros: [String: Macro.Type] = [
-    "email": EmailValidationMacro.self,
-]
+    let testMacros: [String: Macro.Type] = [
+        "email": EmailValidationMacro.self
+    ]
 #endif
 
 final class EmailValidationTests: XCTestCase {
-    
+
     func testValidEmail() throws {
-    #if canImport(EmailValidationMacros)
-        assertMacroExpansion(
-            """
-            #email("foo@email.com")
-            """,
-            expandedSource:
-            """
-            "foo@email.com"
-            """,
-            macros: testMacros
-        )
-    #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+        #if canImport(EmailValidationMacros)
+            assertMacroExpansion(
+                """
+                #email("foo@email.com")
+                """,
+                expandedSource:
+                    """
+                    "foo@email.com"
+                    """,
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
     }
-    
+
     func testInvalidEmailMalformed() throws {
-    #if canImport(EmailValidationMacros)
-        assertMacroExpansion(
-            """
-            #email("invalid-email")
-            """,
-            expandedSource:
-            """
-            #email("invalid-email")
-            """,
-            diagnostics: [
-                DiagnosticSpec(message: "The input email is malformed", line: 1, column: 1)
-            ],
-            macros: testMacros
-        )
-    #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+        #if canImport(EmailValidationMacros)
+            assertMacroExpansion(
+                """
+                #email("invalid-email")
+                """,
+                expandedSource:
+                    """
+                    #email("invalid-email")
+                    """,
+                diagnostics: [
+                    DiagnosticSpec(message: "The input email is malformed", line: 1, column: 1)
+                ],
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
     }
-    
+
     func testInvalidEmailStaticStringLiteral() throws {
-    #if canImport(EmailValidationMacros)
-        assertMacroExpansion(
-            #"""
-            #email("\(randomString(length: 2))@email.com")
-            """#,
-            expandedSource:
-            #"""
-            #email("\(randomString(length: 2))@email.com")
-            """#,
-            diagnostics: [
-                DiagnosticSpec(message: "Requires a static string literal", line: 1, column: 1)
-            ],
-            macros: testMacros
-        )
-    #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
-    #endif
+        #if canImport(EmailValidationMacros)
+            assertMacroExpansion(
+                #"""
+                #email("\(randomString(length: 2))@email.com")
+                """#,
+                expandedSource:
+                    #"""
+                    #email("\(randomString(length: 2))@email.com")
+                    """#,
+                diagnostics: [
+                    DiagnosticSpec(message: "Requires a static string literal", line: 1, column: 1)
+                ],
+                macros: testMacros
+            )
+        #else
+            throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
     }
 }

--- a/Tests/EmailValidationTests/EmailValidationTests.swift
+++ b/Tests/EmailValidationTests/EmailValidationTests.swift
@@ -4,43 +4,69 @@ import XCTest
 
 // Macro implementations build for the host, so the corresponding module is not available when cross-compiling. Cross-compiled tests may still make use of the macro itself in end-to-end tests.
 #if canImport(EmailValidationMacros)
-    import EmailValidationMacros
+import EmailValidationMacros
 
-    let testMacros: [String: Macro.Type] = [
-        "stringify": StringifyMacro.self
-    ]
+let testMacros: [String: Macro.Type] = [
+    "email": EmailValidationMacro.self,
+]
 #endif
 
 final class EmailValidationTests: XCTestCase {
-    func testMacro() throws {
-        #if canImport(EmailValidationMacros)
-            assertMacroExpansion(
-                """
-                #stringify(a + b)
-                """,
-                expandedSource: """
-                    (a + b, "a + b")
-                    """,
-                macros: testMacros
-            )
-        #else
-            throw XCTSkip("macros are only supported when running tests for the host platform")
-        #endif
+    
+    func testValidEmail() throws {
+    #if canImport(EmailValidationMacros)
+        assertMacroExpansion(
+            """
+            #email("foo@email.com")
+            """,
+            expandedSource:
+            """
+            "foo@email.com"
+            """,
+            macros: testMacros
+        )
+    #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+    #endif
     }
-
-    func testMacroWithStringLiteral() throws {
-        #if canImport(EmailValidationMacros)
-            assertMacroExpansion(
-                #"""
-                #stringify("Hello, \(name)")
-                """#,
-                expandedSource: #"""
-                    ("Hello, \(name)", #""Hello, \(name)""#)
-                    """#,
-                macros: testMacros
-            )
-        #else
-            throw XCTSkip("macros are only supported when running tests for the host platform")
-        #endif
+    
+    func testInvalidEmailMalformed() throws {
+    #if canImport(EmailValidationMacros)
+        assertMacroExpansion(
+            """
+            #email("invalid-email")
+            """,
+            expandedSource:
+            """
+            #email("invalid-email")
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: "The input email is malformed", line: 1, column: 1)
+            ],
+            macros: testMacros
+        )
+    #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+    #endif
+    }
+    
+    func testInvalidEmailStaticStringLiteral() throws {
+    #if canImport(EmailValidationMacros)
+        assertMacroExpansion(
+            #"""
+            #email("\(randomString(length: 2))@email.com")
+            """#,
+            expandedSource:
+            #"""
+            #email("\(randomString(length: 2))@email.com")
+            """#,
+            diagnostics: [
+                DiagnosticSpec(message: "Requires a static string literal", line: 1, column: 1)
+            ],
+            macros: testMacros
+        )
+    #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+    #endif
     }
 }


### PR DESCRIPTION
**CHANGELOG**
- Added a macro to validate email addresses in `EmailValidation.swift`.
- Added a new file `EmailValidationMacroError.swift` to define custom errors related to the email validation macro.
- Updated tests in `EmailValidationTests.swift` to include tests for the `email` macro, checking both valid and invalid email addresses.
- Updated the `README.md` file to include sections for Basic Usage and Installation.