### PR TITLE
feat: Enable code coverage and integrate with Coveralls

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,4 +19,6 @@ jobs:
       - name: Build
         run: swift build
       - name: Test
-        run: swift test
+        run: swift test --enable-code-coverage
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Test
         run: |
           swift test --enable-code-coverage
-          xcrun llvm-cov export -format="lcov" .build/debug/EmailValidationPackageTests.xctest/Contents/MacOS/EmailValidationPackageTests -instr-profile .build/debug/codecov/default.profdata -ignore-filename-regex='Tests.swift' -ignore-filename-regex='EmailValidationMacros.swift' > info.lcov
+          xcrun llvm-cov export -format="lcov" .build/debug/EmailValidationPackageTests.xctest/Contents/MacOS/EmailValidationPackageTests -instr-profile .build/debug/codecov/default.profdata -ignore-filename-regex=".build|Tests" > info.lcov
       - name: Coveralls
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Build
         run: swift build
       - name: Test
-        run: swift test --enable-code-coverage
+        run: |
+          swift test --enable-code-coverage
+          xcrun llvm-cov export -format="lcov" .build/debug/EmailValidationPackageTests.xctest/Contents/MacOS/EmailValidationPackageTests -instr-profile .build/debug/codecov/default.profdata -ignore-filename-regex='Tests.swift' -ignore-filename-regex='EmailValidationMacros.swift' > info.lcov
       - name: Coveralls
         uses: coverallsapp/github-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+*.lcov

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Email Validation Macro
 
 [![CodeFactor](https://www.codefactor.io/repository/github/josetorronteras/emailvalidationmacro/badge)](https://www.codefactor.io/repository/github/josetorronteras/emailvalidationmacro)
+[![testing](https://github.com/josetorronteras/EmailValidationMacro/actions/workflows/testing.yml/badge.svg)](https://github.com/josetorronteras/EmailValidationMacro/actions/workflows/testing.yml)
 
 Email Validation Macro is a Swift macro framework for validating email addresses.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![testing](https://github.com/josetorronteras/EmailValidationMacro/actions/workflows/testing.yml/badge.svg)](https://github.com/josetorronteras/EmailValidationMacro/actions/workflows/testing.yml)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fjosetorronteras%2FEmailValidationMacro%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/josetorronteras/EmailValidationMacro)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fjosetorronteras%2FEmailValidationMacro%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/josetorronteras/EmailValidationMacro)
+[![Coverage Status](https://coveralls.io/repos/github/josetorronteras/EmailValidationMacro/badge.svg?branch=main)](https://coveralls.io/github/josetorronteras/EmailValidationMacro?branch=main)
 
 Email Validation Macro is a Swift macro framework for validating email addresses.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CodeFactor](https://www.codefactor.io/repository/github/josetorronteras/emailvalidationmacro/badge)](https://www.codefactor.io/repository/github/josetorronteras/emailvalidationmacro)
 [![testing](https://github.com/josetorronteras/EmailValidationMacro/actions/workflows/testing.yml/badge.svg)](https://github.com/josetorronteras/EmailValidationMacro/actions/workflows/testing.yml)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fjosetorronteras%2FEmailValidationMacro%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/josetorronteras/EmailValidationMacro)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fjosetorronteras%2FEmailValidationMacro%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/josetorronteras/EmailValidationMacro)
 
 Email Validation Macro is a Swift macro framework for validating email addresses.
 


### PR DESCRIPTION
- Enable code coverage during testing by adding the "--enable-code-coverage" flag to the "swift test" command.
- Integrate with Coveralls for code coverage reporting by adding a step to the testing workflow that uses the "coverallsapp/github-action@v2" action.